### PR TITLE
Add custom link handlers

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -269,8 +269,11 @@ version = "2.1.2"
 dependencies = [
  "serde",
  "serde_json",
+ "sysinfo",
  "tauri",
  "tauri-build",
+ "url",
+ "webbrowser",
 ]
 
 [[package]]
@@ -393,6 +396,31 @@ checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "once_cell",
+ "scopeguard",
 ]
 
 [[package]]
@@ -587,6 +615,12 @@ checksum = "bde03329ae10e79ede66c9ce4dc930aa8599043b0743008548680f25b91502d6"
 dependencies = [
  "dtoa",
 ]
+
+[[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "embed-resource"
@@ -1525,6 +1559,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
+name = "ndk-glue"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d0c4a7b83860226e6b4183edac21851f05d5a51756e97a1144b7f5a6b63e65f"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "ndk",
+ "ndk-context",
+ "ndk-macro",
+ "ndk-sys",
+]
+
+[[package]]
+name = "ndk-macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0df7ac00c4672f9d5aece54ee3347520b7e20f158656c7db2e6de01902eb7a6c"
+dependencies = [
+ "darling",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ndk-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,6 +1616,15 @@ dependencies = [
  "dbus",
  "mac-notification-sys",
  "winrt-notification",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -2156,6 +2227,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2636,6 +2731,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae2421f3e16b3afd4aa692d23b83d0ba42ee9b0081d5deeb7d21428d7195fb1"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
 ]
 
 [[package]]
@@ -3311,6 +3421,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a3cffdb686fbb24d9fb8f03a213803277ed2300f11026a3afe1f108dc021b"
+dependencies = [
+ "jni 0.19.0",
+ "ndk-glue",
+ "url",
+ "web-sys",
+ "widestring",
+ "winapi",
+]
+
+[[package]]
 name = "webkit2gtk"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3393,6 +3517,12 @@ dependencies = [
  "windows 0.37.0",
  "windows-bindgen",
 ]
+
+[[package]]
+name = "widestring"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
 
 [[package]]
 name = "wildmatch"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -267,13 +267,13 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "cinny"
 version = "2.1.2"
 dependencies = [
+ "open",
  "serde",
  "serde_json",
  "sysinfo",
  "tauri",
  "tauri-build",
  "url",
- "webbrowser",
 ]
 
 [[package]]
@@ -1559,34 +1559,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
-name = "ndk-glue"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0c4a7b83860226e6b4183edac21851f05d5a51756e97a1144b7f5a6b63e65f"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "ndk",
- "ndk-context",
- "ndk-macro",
- "ndk-sys",
-]
-
-[[package]]
-name = "ndk-macro"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df7ac00c4672f9d5aece54ee3347520b7e20f158656c7db2e6de01902eb7a6c"
-dependencies = [
- "darling",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "ndk-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,9 +1727,9 @@ checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "open"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23a407004a1033f53e93f9b45580d14de23928faad187384f891507c9b0c045"
+checksum = "b4a3100141f1733ea40b53381b0ae3117330735ef22309a190ac57b9576ea716"
 dependencies = [
  "pathdiff",
  "windows-sys",
@@ -3421,20 +3393,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webbrowser"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a3cffdb686fbb24d9fb8f03a213803277ed2300f11026a3afe1f108dc021b"
-dependencies = [
- "jni 0.19.0",
- "ndk-glue",
- "url",
- "web-sys",
- "widestring",
- "winapi",
-]
-
-[[package]]
 name = "webkit2gtk"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3517,12 +3475,6 @@ dependencies = [
  "windows 0.37.0",
  "windows-bindgen",
 ]
-
-[[package]]
-name = "widestring"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
 
 [[package]]
 name = "wildmatch"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ tauri-build = { version = "1.0.4", features = [] }
 serde_json = "1.0.82"
 serde = { version = "1.0.141", features = ["derive"] }
 tauri = { version = "1.0.5", features = ["api-all", "devtools", "updater"] }
-webbrowser = "0.7.1"
+open = "3.0.3"
 url = "2.2.2"
 sysinfo = "0.26.2"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,9 @@ tauri-build = { version = "1.0.4", features = [] }
 serde_json = "1.0.82"
 serde = { version = "1.0.141", features = ["derive"] }
 tauri = { version = "1.0.5", features = ["api-all", "devtools", "updater"] }
+webbrowser = "0.7.1"
+url = "2.2.2"
+sysinfo = "0.26.2"
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/link_handler.rs
+++ b/src-tauri/src/link_handler.rs
@@ -1,0 +1,51 @@
+
+use webbrowser;
+use url;
+
+pub mod steam;
+
+type Action = fn(&url::Url) -> bool;
+
+static FUNCTIONS: &'static [(&'static str, Action)] = &[
+    ("steamcommunity.com", steam::handle_steam),
+    ("store.steampowered.com", steam::handle_steam)
+];
+
+fn handle_default(url: &url::Url) -> bool{
+    webbrowser::open(url.as_str()).unwrap();
+    return true;
+}
+
+fn find_action(prog: &String) -> Option<Action> {
+    match FUNCTIONS.binary_search_by(|&(name,_)| name.cmp(prog)) {
+        Ok(idx) => Some(FUNCTIONS[idx].1),
+        Err(_) => None,
+    }
+}
+
+fn invoke(args: &url::Url, bypass_handlers: bool) -> bool {
+
+    if bypass_handlers { return handle_default(args); }
+
+    let host = String::from(args.host_str().unwrap());
+
+    let mut result = match find_action(&host) {
+        Some(action) => action(args),
+        None => handle_default(args),
+    };
+
+    if !result {
+        result = handle_default(args);
+    }
+
+    return result;
+}
+
+#[tauri::command]
+pub(crate) fn open_link(url: String, bypass_handlers: bool){
+    println!("Opening link: {}", url);
+
+    let parsed_url = url::Url::parse(&url).unwrap();
+
+    invoke(&parsed_url, bypass_handlers);
+}

--- a/src-tauri/src/link_handler/steam.rs
+++ b/src-tauri/src/link_handler/steam.rs
@@ -11,11 +11,16 @@ pub(crate) fn process_is_running(name: &str) -> bool{
 // open a link using the steam browser protocol: steam://openurl/<url>
 // see: https://developer.valvesoftware.com/wiki/Steam_browser_protocol
 pub fn handle_steam(url: &url::Url) -> bool{
+
     if process_is_running("steam") {
         let mut uri = String::from("steam://openurl/");
         uri.push_str(url.as_str());
-        webbrowser::open(&uri).unwrap();
-        return true;
+        let result = match open::that(&uri) {
+            Ok(_) => true,
+            Err(_) => false
+        };
+        return result;
     }
+
     return false;
 }

--- a/src-tauri/src/link_handler/steam.rs
+++ b/src-tauri/src/link_handler/steam.rs
@@ -1,0 +1,21 @@
+use sysinfo::{System, SystemExt};
+
+pub(crate) fn process_is_running(name: &str) -> bool{
+    let s = System::new_all();
+    for _process in s.processes_by_exact_name(name) {
+        return true
+    }
+    return false;
+}
+
+// open a link using the steam browser protocol: steam://openurl/<url>
+// see: https://developer.valvesoftware.com/wiki/Steam_browser_protocol
+pub fn handle_steam(url: &url::Url) -> bool{
+    if process_is_running("steam") {
+        let mut uri = String::from("steam://openurl/");
+        uri.push_str(url.as_str());
+        webbrowser::open(&uri).unwrap();
+        return true;
+    }
+    return false;
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,6 +6,8 @@
 #[cfg(target_os = "macos")]
 mod menu;
 
+mod link_handler;
+
 fn main() {
   let builder = tauri::Builder::default();
 
@@ -13,6 +15,7 @@ fn main() {
   let builder = builder.menu(menu::menu());
 
   builder
+    .invoke_handler(tauri::generate_handler![link_handler::open_link])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");
 }


### PR DESCRIPTION
### Description
Adds the ability for the Tauri backend to handle the opening of links. This allows for certain links to be opened in a specific application, as well as fixing an issue where clicking a link in Cinny Desktop would navigate to that URL inside the tauri window.

I added an example link handler, for steamcommunity.com, and store.steampowered.com, which opens these urls inside the Steam app, if Steam is running on the user's computer.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### Related: https://github.com/cinnyapp/cinny/pull/790