### PR TITLE
Add ctrl+q and prepare ctrl+w keybinds

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build = { version = "1.2.1", features = [] }
 [dependencies]
 serde_json = "1.0.91"
 serde = { version = "1.0.152", features = ["derive"] }
-tauri = { version = "1.2.3", features = ["api-all", "devtools", "updater"] }
+tauri = { version = "1.2.3", features = ["api-all", "devtools", "global-shortcut", "updater"] }
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,6 +5,7 @@
 
 #[cfg(target_os = "macos")]
 mod menu;
+mod shortcuts;
 
 fn main() {
   let builder = tauri::Builder::default();
@@ -12,7 +13,17 @@ fn main() {
   #[cfg(target_os = "macos")]
   let builder = builder.menu(menu::menu());
 
-  builder
-    .run(tauri::generate_context!())
-    .expect("error while running tauri application");
+    builder
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(run_event_handler)
+}
+
+fn run_event_handler<R: tauri::Runtime>(app: &tauri::AppHandle<R>, event: tauri::RunEvent) {
+    match event {
+        tauri::RunEvent::Ready => {
+            shortcuts::ready_event_handler(app);
+        }
+        _ => {}
+    }
 }

--- a/src-tauri/src/shortcuts.rs
+++ b/src-tauri/src/shortcuts.rs
@@ -6,18 +6,20 @@ pub fn ready_event_handler<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>
 ) {
     let manager = app.global_shortcut_manager();
-    manager.clone().register("CmdOrCtrl+w", hide_closure(app)).unwrap();
+    //manager.clone().register("CmdOrCtrl+w", hide_closure(app)).unwrap();
     manager.clone().register("CmdOrCtrl+q", close_closure(app)).unwrap();
 }
 
+/*
 fn hide_closure<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> impl Fn() {
     let window = app.get_window("main").unwrap();
-    //let app = app.clone();
+    let app = app.clone();
     return move || {
         window.hide().unwrap();
-        //tray::toggle_window_state(window.clone(), app.tray_handle_by_id(tray::TRAY_LABEL).unwrap())
+        tray::toggle_window_state(window.clone(), app.tray_handle_by_id(tray::TRAY_LABEL).unwrap())
     }
 }
+*/
 
 fn close_closure<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> impl Fn() {
     let window = app.get_window("main").unwrap();

--- a/src-tauri/src/shortcuts.rs
+++ b/src-tauri/src/shortcuts.rs
@@ -1,0 +1,25 @@
+use tauri::{ GlobalShortcutManager, Manager };
+
+//use crate::tray;
+
+pub fn ready_event_handler<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>
+) {
+    let manager = app.global_shortcut_manager();
+    manager.clone().register("CmdOrCtrl+w", hide_closure(app)).unwrap();
+    manager.clone().register("CmdOrCtrl+q", close_closure(app)).unwrap();
+}
+
+fn hide_closure<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> impl Fn() {
+    let window = app.get_window("main").unwrap();
+    //let app = app.clone();
+    return move || {
+        window.hide().unwrap();
+        //tray::toggle_window_state(window.clone(), app.tray_handle_by_id(tray::TRAY_LABEL).unwrap())
+    }
+}
+
+fn close_closure<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> impl Fn() {
+    let window = app.get_window("main").unwrap();
+    return move || window.close().unwrap();
+}


### PR DESCRIPTION
<!-- Please read https://github.com/cinnyapp/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Fixes #204

Lifts event handler logic from paste image support (#167).

Includes some commented out logic for compatibility with systray (#166) when/if merged. Requires `TRAY_LABEL` in `tray.rs` be exposed as public. 

If I catch that the referenced PRs get merged before this one I'll resolve conflicts and uncomment code as necessary. That said, this PR on its own is ready to be merged if the maintainers want to handle the conflicts and changes I've mentioned.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
