### PR TITLE
Add single-instance tauri plugin

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -450,6 +450,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-single-instance",
 ]
 
 [[package]]
@@ -3629,6 +3630,20 @@ dependencies = [
  "syn 1.0.105",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "0.0.0"
+source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v1#562425644ef7c11a7b301a30c07a8c8b545621a8"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror",
+ "windows-sys 0.52.0",
+ "zbus",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ tauri-build = { version = "1.5.2", features = [] }
 serde_json = "1.0.109"
 serde = { version = "1.0.193", features = ["derive"] }
 tauri = { version = "1.6.7", features = ["api-all", "devtools", "system-tray", "updater"] }
+tauri-plugin-single-instance = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,6 +2,8 @@
     all(not(debug_assertions), target_os = "windows"),
     windows_subsystem = "windows"
 )]
+
+use tauri::Manager;
 #[cfg(target_os = "macos")]
 mod menu;
 mod tray;
@@ -17,6 +19,23 @@ fn main() {
         .on_system_tray_event(tray::system_tray_handler);
 
     builder
+        .plugin(tauri_plugin_single_instance::init(|app, _, _| {
+            let tray_handle = match app.tray_handle_by_id(crate::tray::TRAY_LABEL) {
+                Some(h) => h,
+                None => return,
+            };
+            let window = app.get_window("main").unwrap();
+
+            if !window.is_visible().unwrap() || window.is_minimized().unwrap() {
+                window.unminimize().unwrap();
+                window.show().unwrap();
+                window.set_focus().unwrap();
+                tray_handle
+                    .get_item("toggle")
+                    .set_title("Hide Cinny")
+                    .unwrap();
+            }
+        }))
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
         .run(run_event_handler)

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -3,7 +3,7 @@ use tauri::{
     SystemTrayMenuItem, WindowEvent, SystemTrayHandle, Window,
 };
 
-const TRAY_LABEL: &'static str = "main-tray";
+pub const TRAY_LABEL: &'static str = "main-tray";
 
 pub fn window_event_handler<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,


### PR DESCRIPTION
### Description

Uses official tauri plugin.

~Currently, if minimized _and_ hidden, it will show but not unminimiz.
Also after being shown by a second instance, the tray menu will continue to say "Show Cinny" while it should "Hide Cinny" as it is now shown.~
cc https://github.com/tauri-apps/plugins-workspace/issues/280

Fixes #210

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
