### PR TITLE
ci: build universal binary for macos

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -124,8 +124,8 @@ jobs:
             src-tauri/target/release/bundle/appimage/Cinny_desktop-x86_64.AppImage.tar.gz
             src-tauri/target/release/bundle/appimage/Cinny_desktop-x86_64.AppImage.tar.gz.sig
 
-  # macos-x86_64
-  macos-x86_64:
+  # macos-universal
+  macos-universal:
     runs-on: macos-latest
     steps:
       - name: Checkout repository
@@ -146,6 +146,7 @@ jobs:
         uses: actions-rs/toolchain@v1.0.7
         with:
           toolchain: stable
+          targets: x86_64-apple-darwin,aarch64-apple-darwin
       - name: Install cinny dependencies
         run: cd cinny && npm ci
       - name: Install tauri dependencies
@@ -159,87 +160,28 @@ jobs:
           NODE_OPTIONS: "--max_old_space_size=4096"
         with:
           releaseId: ${{ steps.get_release.outputs.upload_url }}
+          args: "--target universal-apple-darwin"
       - name: Get app version
         id: vars
         run: echo ::set-output name=tag::$(jq .package.version src-tauri/tauri.conf.json | tr -d '"')
       - name: Move dmg
-        run: mv "src-tauri/target/release/bundle/dmg/Cinny_${{ steps.vars.outputs.tag }}_x64.dmg" "src-tauri/target/release/bundle/dmg/Cinny_desktop-x86_64.dmg"
+        run: mv "src-tauri/target/release/bundle/dmg/Cinny_${{ steps.vars.outputs.tag }}_universal.dmg" "src-tauri/target/release/bundle/dmg/Cinny_desktop-universal.dmg"
       - name: Move app.tar.gz
-        run: mv "src-tauri/target/release/bundle/macos/Cinny.app.tar.gz" "src-tauri/target/release/bundle/macos/Cinny_desktop-x86_64.app.tar.gz"
+        run: mv "src-tauri/target/release/bundle/macos/Cinny.app.tar.gz" "src-tauri/target/release/bundle/macos/Cinny_desktop-universal.app.tar.gz"
       - name: Move app.tar.gz.sig
-        run: mv "src-tauri/target/release/bundle/macos/Cinny.app.tar.gz.sig" "src-tauri/target/release/bundle/macos/Cinny_desktop-x86_64.app.tar.gz.sig"
+        run: mv "src-tauri/target/release/bundle/macos/Cinny.app.tar.gz.sig" "src-tauri/target/release/bundle/macos/Cinny_desktop-universal.app.tar.gz.sig"
       - name: Upload tagged release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         with:
           files: |
-            src-tauri/target/release/bundle/dmg/Cinny_desktop-x86_64.dmg
-            src-tauri/target/release/bundle/macos/Cinny_desktop-x86_64.app.tar.gz
-            src-tauri/target/release/bundle/macos/Cinny_desktop-x86_64.app.tar.gz.sig
-
-  # macos-aarch64
-  # macos-aarch64:
-  #   runs-on: macos-12
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v3.5.3
-  #       with: 
-  #         submodules: true
-  #     - name: Get release
-  #       id: get_release
-  #       uses: bruceadams/get-release@74c3d60f5a28f358ccf241a00c9021ea16f0569f
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #     - name: Setup node
-  #       uses: actions/setup-node@v3.4.1
-  #       with:
-  #         node-version: 18.12.1
-  #         cache: 'npm'
-  #     - name: Install Rust stable
-  #       uses: actions-rs/toolchain@v1.0.7
-  #       with:
-  #         toolchain: stable
-  #     - name: Install cinny dependencies
-  #       run: cd cinny && npm ci
-  #     - name: Install tauri dependencies
-  #       run: npm ci
-  #     - name: Install rustup target aarch64 darwin
-  #       run: rustup target add aarch64-apple-darwin
-  #     - name: Build desktop app with Tauri
-  #       uses: tauri-apps/tauri-action@v0.3.1
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
-  #         TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
-  #         NODE_OPTIONS: "--max_old_space_size=4096"
-  #       with:
-  #         args: --target aarch64-apple-darwin
-  #         releaseId: ${{ steps.get_release.outputs.upload_url }}
-  #     - name: Get app version
-  #       if: always()
-  #       id: vars
-  #       run: echo ::set-output name=tag::$(jq .package.version src-tauri/tauri.conf.json | tr -d '"')
-  #     - name: Move dmg
-  #       if: always()
-  #       run: mv "src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/Cinny_${{ steps.vars.outputs.tag }}_aarch64.dmg" "src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/Cinny_desktop-aarch64.dmg"
-  #     - name: Move app.tar.gz
-  #       if: always()
-  #       run: mv "src-tauri/target/aarch64-apple-darwin/release/bundle/macos/Cinny.app.tar.gz" "src-tauri/target/aarch64-apple-darwin/release/bundle/macos/Cinny_desktop-aarch64.app.tar.gz"
-  #     - name: Move app.tar.gz.sig
-  #       if: always()
-  #       run: mv "src-tauri/target/aarch64-apple-darwin/release/bundle/macos/Cinny.app.tar.gz.sig" "src-tauri/target/aarch64-apple-darwin/release/bundle/macos/Cinny_desktop-aarch64.app.tar.gz.sig"
-  #     - name: Upload tagged release
-  #       if: always()
-  #       uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
-  #       with:
-  #         files: |
-  #           src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/Cinny_desktop-aarch64.dmg
-  #           src-tauri/target/aarch64-apple-darwin/release/bundle/macos/Cinny_desktop-aarch64.tar.gz
-  #           src-tauri/target/aarch64-apple-darwin/release/bundle/macos/Cinny_desktop-aarch64.tar.gz.sig
+            src-tauri/target/release/bundle/dmg/Cinny_desktop-universal.dmg
+            src-tauri/target/release/bundle/macos/Cinny_desktop-universal.app.tar.gz
+            src-tauri/target/release/bundle/macos/Cinny_desktop-universal.app.tar.gz.sig
 
   # Upload release.json
   release-update:
     if: always()
-    needs: [windows-x86_64, linux-x86_64, macos-x86_64] #, macos-aarch64]
+    needs: [windows-x86_64, linux-x86_64, macos-universal]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### Description

Make Tauri build universal binary for macOS

Reference to my previous work: https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/pull/3711

Will solve *half* of #62

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
