### PR TITLE
Add Homebrew Cask for Cinny

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
     #[cfg(target_os = "macos")]
     let builder = builder.menu(menu::menu());
 
-    builder
+    builderaaa
         .plugin(tauri_plugin_localhost::Builder::new(port).build())
         .run(context)
         .expect("error while building tauri application")


### PR DESCRIPTION
<!-- Please read https://github.com/cinnyapp/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Adds a Cask formula to install Cinny using the Homebrew package manager.

Finally fixes https://github.com/cinnyapp/cinny-desktop/issues/62

After this PR, Cinny can be installed with:
```
brew tap cinnyapp/cinny-desktop https://github.com/cinnyapp/cinny-desktop
brew install cinny
```

The Cask formula could be moved into its own separate `homebrew-tap` repo under the Cinny project. See https://github.com/cinnyapp/cinny-desktop/issues/62#issuecomment-2250129047

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
