### PR TITLE
Add ability to restore Cinny's window size and position

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = "1.0.109"
 serde = { version = "1.0.193", features = ["derive"] }
 tauri = { version = "1.8.0", features = ["api-all", "devtools", "updater"] }
 tauri-plugin-localhost = "0.1.0"
+tauri-plugin-window-state = "0.1.1"
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -24,6 +24,7 @@ fn main() {
 
     builder
         .plugin(tauri_plugin_localhost::Builder::new(port).build())
+        .plugin(tauri_plugin_window_state::Builder::default().build())
         .run(context)
         .expect("error while building tauri application")
 }


### PR DESCRIPTION
### Description

Enables Cinny on macOS to restore its window state from past sessions, using Tauri's [`window-state`](https://github.com/tauri-apps/plugins-workspace/tree/v2/plugins/window-state).

Fixes #326 #125

Note that `v2` isn’t used to prevent conflicts with `gtk-3`. We might switch to v2 later, but for now we’re sticking with `v1` to avoid breaking issues.

#### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
