### PR TITLE
Prevent macOS app-nap

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -479,6 +479,7 @@ checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 name = "cinny"
 version = "4.4.0"
 dependencies = [
+ "macos-app-nap",
  "serde",
  "serde_json",
  "tauri",
@@ -1898,6 +1899,17 @@ dependencies = [
  "objc-foundation",
  "objc_id",
  "time",
+]
+
+[[package]]
+name = "macos-app-nap"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9701bd74bcff7fb5f9bff8ff4930a889a55f9cccc8a0dfc4c51ea08b786f0c6a"
+dependencies = [
+ "cc",
+ "cocoa-foundation",
+ "objc",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,6 +14,9 @@ rust-version = "1.61"
 [build-dependencies]
 tauri-build = { version = "1.5.5", features = [] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+macos-app-nap = "0.0"
+
 [dependencies]
 serde_json = "1.0.109"
 serde = { version = "1.0.193", features = ["derive"] }
@@ -24,7 +27,7 @@ tauri-plugin-window-state = "0.1.1"
 [features]
 # by default Tauri runs in production mode
 # when `tauri dev` runs it is executed with `cargo run --no-default-features` if `devPath` is an URL
-default = [ "custom-protocol" ]
+default = ["custom-protocol"]
 # this feature is used used for production builds where `devPath` points to the filesystem
 # DO NOT remove this
-custom-protocol = [ "tauri/custom-protocol" ]
+custom-protocol = ["tauri/custom-protocol"]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,6 +12,12 @@ fn main() {
     let port = 44548;
 
     let mut context = tauri::generate_context!();
+
+    // macOS "App Nap" periodically pauses our app when it's in the background.
+    // We need to prevent that so our intervals are not interrupted.
+    #[cfg(target_os = "macos")]
+    macos_app_nap::prevent();
+
     let url = format!("http://localhost:{}", port).parse().unwrap();
     let window_url = WindowUrl::External(url);
     // rewrite the config so the IPC is enabled on this URL


### PR DESCRIPTION
<!-- Please read https://github.com/cinnyapp/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

On macOS, when Cinny is in the background for a while, app-nap suspends it and the next time when it regains focus Cinny displays a "disconnected, reocnnecting" message.

This change disables app-nap using the macos-app-nap crate

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
