### PR TITLE
fix: use devUrl when dev

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,8 +21,17 @@ pub fn run() {
         .plugin(tauri_plugin_localhost::Builder::new(port).build())
         .plugin(tauri_plugin_window_state::Builder::default().build())
         .setup(move |app| {
-            let url = format!("http://localhost:{}", port).parse().unwrap();
-            let window_url = WebviewUrl::External(url);
+            // Dev: use devUrl from tauri.conf.json (http://localhost:8080) to support HMR
+            #[cfg(debug_assertions)]
+            let window_url = WebviewUrl::App(Default::default());
+
+            // Release: tauri-plugin-localhost serves bundled frontend assets on this port
+            #[cfg(not(debug_assertions))]
+            let window_url = {
+                let url = format!("http://localhost:{}", port).parse().unwrap();
+                WebviewUrl::External(url)
+            };
+
             WebviewWindowBuilder::new(app, "main".to_string(), window_url)
                 .title("Cinny")
                 .build()?;


### PR DESCRIPTION
<!-- Please read https://github.com/cinnyapp/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Fix  blank app when using `npm run tauri dev`

Fixes #555 

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
