### PR TITLE
fix: disable Tauri native drag-drop handler

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,6 +34,7 @@ pub fn run() {
 
             WebviewWindowBuilder::new(app, "main".to_string(), window_url)
                 .title("Cinny")
+                .disable_drag_drop_handler()
                 .build()?;
             Ok(())
         })


### PR DESCRIPTION
## Description

After updating Tauri from v1 to v2, uploading files by dragging and dropping stopped working. Tauri v2 intercepts drag-and-drop events at the webview level, preventing the events from reaching the frontend.

This PR fixes the issue by disabling Tauri's default drag-and-drop handler, allowing drag-and-drop events to reach frontend and restoring the expected file upload behavior.

```
Whether the drag and drop is enabled or not on the webview. By default it is enabled.

Disabling it is required to use HTML5 drag and drop on the frontend on Windows.
```
Source: https://tauri.app/reference/config/#windowconfig

Fixes cinnyapp/cinny#2829.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings