### PR TITLE
fix: re-enable devtools in release builds after regression caused by tauri v2

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,8 +5,6 @@
 
 // mod menu;
 
-use tauri::{webview::WebviewWindowBuilder, WebviewUrl};
-
 pub fn run() {
     let port: u16 = 44548;
     let context = tauri::generate_context!();
@@ -20,23 +18,6 @@ pub fn run() {
     builder
         .plugin(tauri_plugin_localhost::Builder::new(port).build())
         .plugin(tauri_plugin_window_state::Builder::default().build())
-        .setup(move |app| {
-            // Dev: use devUrl from tauri.conf.json (http://localhost:8080) to support HMR
-            #[cfg(debug_assertions)]
-            let window_url = WebviewUrl::App(Default::default());
-
-            // Release: tauri-plugin-localhost serves bundled frontend assets on this port
-            #[cfg(not(debug_assertions))]
-            let window_url = {
-                let url = format!("http://localhost:{}", port).parse().unwrap();
-                WebviewUrl::External(url)
-            };
-
-            WebviewWindowBuilder::new(app, "main".to_string(), window_url)
-                .title("Cinny")
-                .build()?;
-            Ok(())
-        })
         .run(context)
         .expect("error while building tauri application");
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -70,7 +70,8 @@
         "resizable": true,
         "fullscreen": false,
         "dragDropEnabled": false,
-        "useHttpsScheme": true
+        "useHttpsScheme": true,
+        "devtools": true
       }
     ]
   }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -60,6 +60,18 @@
   "app": {
     "security": {
       "csp": "default-src 'self' blob: data: filesystem: ws: wss: http: https: tauri:; script-src 'self' 'unsafe-eval' 'unsafe-inline' blob: data: filesystem: ws: wss: http: https: tauri:; img-src 'self' data: blob: filesystem: http: https:; connect-src 'self' blob: ipc: ws: wss: http: https: http://ipc.localhost"
-    }
+    },
+    "windows": [
+      {
+        "title": "Cinny",
+        "width": 1280,
+        "height": 905,
+        "center": true,
+        "resizable": true,
+        "fullscreen": false,
+        "dragDropEnabled": false,
+        "useHttpsScheme": true
+      }
+    ]
   }
 }


### PR DESCRIPTION
# Devtools
i haven't done full commit-per-commit testing but it seems like switching to Tauri v2 disabled devtools by default in release builds. This was available in v4.10.5 and prior.

# Window creation
This pull request also reverses #539 (while still fixing the same issue (#540)) by making Tauri automatically handle the window creation, and reintroduces configuration in the JSON config (src-tauri/tauri.conf.json).
These configuration options are useful, because they expose a simple way to configure window behaviour (and style, somewhat), see https://v2.tauri.app/reference/config/#windowconfig, including the re-enabling of devtools this PR was originally made for.
It also directly fixes #555 while not requiring obscure-ish code that basically reimplements what Tauri does behind the scenes

<details><summary>Removal of the `setup` building step</summary>
As it isn't needed anymore, I simply got rid of it
If a tauri building setup step ever needs to be reimplemented for some feature you can't configure in tauri.conf.json, consider using WebviewWindowBuilder::from_config (as recommended in Tauri docs) to use the json config as a base.
That way most of the simple config stays easy to understand and modify

We could also keep the old setup function and add "create": false in
the window's config to tell Tauri to leave the creation up to us.
</details>