### PR TITLE
chore: replace link to tauri v1 docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To verify release files, you need to download [minisign](https://jedisct1.github
 
 ## Local development
 
-Firstly, to setup Rust, NodeJS and build tools follow [Tauri documentation](https://tauri.app/v1/guides/getting-started/prerequisites).
+Firstly, to setup Rust, NodeJS and build tools follow [Tauri documentation](https://v2.tauri.app/start/prerequisites/).
 
 Now, to setup development locally run the following commands:
 * `git clone --recursive https://github.com/cinnyapp/cinny-desktop.git`


### PR DESCRIPTION
now points to tauri v2