### PR TITLE
fix: don't use dev url in debug builds

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,11 +22,12 @@ pub fn run() {
         .plugin(tauri_plugin_window_state::Builder::default().build())
         .setup(move |app| {
             // Dev: use devUrl from tauri.conf.json (http://localhost:8080) to support HMR
-            #[cfg(debug_assertions)]
+            #[cfg(dev)]
             let window_url = WebviewUrl::App(Default::default());
 
             // Release: tauri-plugin-localhost serves bundled frontend assets on this port
-            #[cfg(not(debug_assertions))]
+            // Default would be http://tauri.localhost or tauri://localhost depending on platform
+            #[cfg(not(dev))]
             let window_url = {
                 let url = format!("http://localhost:{}", port).parse().unwrap();
                 WebviewUrl::External(url)


### PR DESCRIPTION
When building in debug mode (`npm run tauri build -- --debug`), we can't use the dev URL, as there won't be a dev server running, which is why we need to use `dev` instead of `debug_assertions` here (see https://v2.tauri.app/develop/debug/#in-rust)