### PR TITLE
refactor: use tauri.config.json for most of the window's configuration

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,9 @@ pub fn run() {
         .plugin(tauri_plugin_localhost::Builder::new(port).build())
         .plugin(tauri_plugin_window_state::Builder::default().build())
         .setup(move |app| {
+            // Use predefined config
+            let mut window_config = app.config().app.windows.iter().find(|c| c.label == "main").unwrap().clone();
+
             // Dev: use devUrl from tauri.conf.json (http://localhost:8080) to support HMR
             #[cfg(dev)]
             let window_url = WebviewUrl::App(Default::default());
@@ -33,9 +36,9 @@ pub fn run() {
                 WebviewUrl::External(url)
             };
 
-            WebviewWindowBuilder::new(app, "main".to_string(), window_url)
-                .title("Cinny")
-                .build()?;
+            window_config.url = window_url;
+
+            WebviewWindowBuilder::from_config(app, &window_config)?.build()?;
             Ok(())
         })
         .run(context)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,11 +22,12 @@ pub fn run() {
         .plugin(tauri_plugin_window_state::Builder::default().build())
         .setup(move |app| {
             // Dev: use devUrl from tauri.conf.json (http://localhost:8080) to support HMR
-            #[cfg(debug_assertions)]
+            #[cfg(dev)]
             let window_url = WebviewUrl::App(Default::default());
 
             // Release: tauri-plugin-localhost serves bundled frontend assets on this port
-            #[cfg(not(debug_assertions))]
+            // Default would be http://tauri.localhost or tauri://localhost depending on platform
+            #[cfg(not(dev))]
             let window_url = {
                 let url = format!("http://localhost:{}", port).parse().unwrap();
                 WebviewUrl::External(url)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,7 +22,14 @@ pub fn run() {
         .plugin(tauri_plugin_window_state::Builder::default().build())
         .setup(move |app| {
             // Use predefined config
-            let mut window_config = app.config().app.windows.iter().find(|c| c.label == "main").unwrap().clone();
+            let mut window_config = app
+                .config()
+                .app
+                .windows
+                .iter()
+                .find(|c| c.label == "main")
+                .unwrap()
+                .clone();
 
             // Dev: use devUrl from tauri.conf.json (http://localhost:8080) to support HMR
             #[cfg(dev)]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -60,6 +60,19 @@
   "app": {
     "security": {
       "csp": "default-src 'self' blob: data: filesystem: ws: wss: http: https: tauri:; script-src 'self' 'unsafe-eval' 'unsafe-inline' blob: data: filesystem: ws: wss: http: https: tauri:; img-src 'self' data: blob: filesystem: http: https:; connect-src 'self' blob: ipc: ws: wss: http: https: http://ipc.localhost"
-    }
+    },
+    "windows": [
+      {
+        "title": "Cinny",
+        "label": "main",
+        "width": 1280,
+        "height": 905,
+        "center": true,
+        "resizable": true,
+        "fullscreen": false,
+        "dragDropEnabled": false,
+        "create": false
+      }
+    ]
   }
 }


### PR DESCRIPTION
This pull request reverses https://github.com/cinnyapp/cinny-desktop/issues/539 (while still fixing the same issue (https://github.com/cinnyapp/cinny-desktop/pull/540)) by making Tauri automatically handle the window creation, and reintroduces configuration in the JSON config (src-tauri/tauri.conf.json).
These configuration options are useful, because they expose a simple way to configure window behaviour (and style, somewhat), see https://v2.tauri.app/reference/config/#windowconfig

Requires #572 (not 100% required but they are kinda stacked since they change code so close together)