### PR TITLE
feat: add system tray with native left-click support on Linux

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -42,6 +42,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +251,17 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "autocfg"
@@ -512,8 +532,9 @@ checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "cinny"
-version = "4.12.1"
+version = "4.12.2"
 dependencies = [
+ "ksni",
  "serde",
  "serde_json",
  "tauri",
@@ -531,6 +552,21 @@ dependencies = [
  "tauri-plugin-shell",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
+]
+
+[[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags 1.3.2",
+ "strsim 0.8.0",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
 ]
 
 [[package]]
@@ -764,7 +800,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.117",
 ]
 
@@ -784,6 +820,37 @@ name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-codegen"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a49da9fdfbe872d4841d56605dc42efa5e6ca3291299b87f44e1cde91a28617c"
+dependencies = [
+ "clap",
+ "dbus",
+ "xml-rs",
+]
+
+[[package]]
+name = "dbus-tree"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f456e698ae8e54575e19ddb1f9b7bce2298568524f215496b248eb9498b4f508"
+dependencies = [
+ "dbus",
+]
 
 [[package]]
 name = "deranged"
@@ -1729,6 +1796,15 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
@@ -2218,6 +2294,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ksni"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4934310bdd016e55725482b8d35ac0c16fd058c1b955d8959aa2d953b918c85b"
+dependencies = [
+ "dbus",
+ "dbus-codegen",
+ "dbus-tree",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2264,6 +2352,15 @@ name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -3208,7 +3305,7 @@ checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
@@ -4409,6 +4506,12 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -5108,6 +5211,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5575,6 +5687,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5634,6 +5752,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version-compare"
@@ -6715,6 +6839,12 @@ name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "yoke"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,6 +42,16 @@ custom-protocol = [ "tauri/custom-protocol" ]
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-updater = "2"
 
+# Native StatusNotifierItem tray on Linux (proper left-click Activate, which
+# Tauri's libayatana-appindicator backend cannot deliver). See src/tray_linux.rs.
+[target.'cfg(target_os = "linux")'.dependencies]
+ksni = "0.2"
+
+# Desktop platforms other than Linux use Tauri's built-in tray. Enabling the
+# tray-icon feature only here keeps libappindicator out of the Linux build.
+[target.'cfg(not(any(target_os = "linux", target_os = "android", target_os = "ios")))'.dependencies]
+tauri = { version = "2", features = ["tray-icon"] }
+
 [lib]
 name = "app_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,10 @@
 )]
 
 // mod menu;
+#[cfg(not(target_os = "linux"))]
+mod tray;
+#[cfg(target_os = "linux")]
+mod tray_linux;
 
 use tauri::{webview::{NewWindowResponse, WebviewWindowBuilder}, WebviewUrl};
 use tauri_plugin_opener::OpenerExt;
@@ -35,7 +39,7 @@ pub fn run() {
             };
 
             let app_handle = app.handle().clone();
-            WebviewWindowBuilder::new(app, "main".to_string(), window_url)
+            let window = WebviewWindowBuilder::new(app, "main".to_string(), window_url)
                 .title("Cinny")
                 .disable_drag_drop_handler()
                 .on_new_window(move |url, _features| {
@@ -43,6 +47,21 @@ pub fn run() {
                     NewWindowResponse::Deny
                 })
                 .build()?;
+
+            // Close to tray: hide the window instead of quitting the app.
+            let win = window.clone();
+            window.on_window_event(move |event| {
+                if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                    api.prevent_close();
+                    let _ = win.hide();
+                }
+            });
+
+            #[cfg(not(target_os = "linux"))]
+            tray::build(app.handle())?;
+            #[cfg(target_os = "linux")]
+            tray_linux::build(app.handle().clone());
+
             Ok(())
         })
         .run(context)

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,0 +1,61 @@
+use tauri::{
+    menu::{Menu, MenuItem},
+    tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
+    AppHandle, Manager, Runtime,
+};
+
+/// Toggle the main window between shown/focused and hidden.
+///
+/// `is_visible` returns true even for a minimized window, so we unminimize
+/// before showing to cover that case.
+fn toggle_window<R: Runtime>(app: &AppHandle<R>) {
+    if let Some(window) = app.get_webview_window("main") {
+        if window.is_visible().unwrap_or(false) {
+            let _ = window.hide();
+        } else {
+            let _ = window.unminimize();
+            let _ = window.show();
+            let _ = window.set_focus();
+        }
+    }
+}
+
+/// Build the system tray.
+///
+/// Left-clicking the icon toggles the main window; the context menu offers an
+/// explicit show/hide toggle and a quit entry. This restores the tray that was
+/// added in #166 and temporarily reverted in #312 (which was a Flatpak/single-
+/// instance packaging issue, unrelated to the tray itself), ported to Tauri v2.
+pub fn build<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
+    let toggle = MenuItem::with_id(app, "toggle", "Show/Hide Cinny", true, None::<&str>)?;
+    let quit = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
+    let menu = Menu::with_items(app, &[&toggle, &quit])?;
+
+    let mut builder = TrayIconBuilder::with_id("main-tray")
+        .tooltip("Cinny")
+        .menu(&menu)
+        // Left click toggles the window; the menu opens on right click.
+        .show_menu_on_left_click(false)
+        .on_menu_event(|app, event| match event.id.as_ref() {
+            "quit" => app.exit(0),
+            "toggle" => toggle_window(app),
+            _ => {}
+        })
+        .on_tray_icon_event(|tray, event| {
+            if let TrayIconEvent::Click {
+                button: MouseButton::Left,
+                button_state: MouseButtonState::Up,
+                ..
+            } = event
+            {
+                toggle_window(tray.app_handle());
+            }
+        });
+
+    if let Some(icon) = app.default_window_icon().cloned() {
+        builder = builder.icon(icon);
+    }
+
+    builder.build(app)?;
+    Ok(())
+}

--- a/src-tauri/src/tray_linux.rs
+++ b/src-tauri/src/tray_linux.rs
@@ -1,0 +1,74 @@
+//! Native StatusNotifierItem tray for Linux, via `ksni`.
+//!
+//! Tauri's built-in tray (the `tray-icon` crate) uses libayatana-appindicator
+//! on Linux, which never forwards a left-click / SNI `Activate` event to the
+//! app — only the context menu works. By implementing the StatusNotifierItem
+//! ourselves (the same approach Qt apps such as Nextcloud use) we get proper
+//! left-click-to-toggle behaviour. The tray runs in its own background thread.
+
+use ksni::{
+    menu::{MenuItem, StandardItem},
+    Tray, TrayService,
+};
+use tauri::{AppHandle, Manager};
+
+/// Toggle the main window between shown/focused and hidden.
+fn toggle_window(app: &AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        if window.is_visible().unwrap_or(false) {
+            let _ = window.hide();
+        } else {
+            let _ = window.unminimize();
+            let _ = window.show();
+            let _ = window.set_focus();
+        }
+    }
+}
+
+struct CinnyTray {
+    app: AppHandle,
+}
+
+impl Tray for CinnyTray {
+    fn id(&self) -> String {
+        "in.cinny.app".into()
+    }
+
+    fn title(&self) -> String {
+        "Cinny".into()
+    }
+
+    // Resolved from the installed hicolor theme (/usr/share/icons/.../cinny.png).
+    fn icon_name(&self) -> String {
+        "cinny".into()
+    }
+
+    // Left click.
+    fn activate(&mut self, _x: i32, _y: i32) {
+        toggle_window(&self.app);
+    }
+
+    fn menu(&self) -> Vec<MenuItem<Self>> {
+        vec![
+            StandardItem {
+                label: "Show/Hide Cinny".into(),
+                activate: Box::new(|this: &mut Self| toggle_window(&this.app)),
+                ..Default::default()
+            }
+            .into(),
+            MenuItem::Separator,
+            StandardItem {
+                label: "Quit".into(),
+                activate: Box::new(|this: &mut Self| this.app.exit(0)),
+                ..Default::default()
+            }
+            .into(),
+        ]
+    }
+}
+
+/// Spawn the native SNI tray on its own thread.
+pub fn build(app: AppHandle) {
+    let service = TrayService::new(CinnyTray { app });
+    service.spawn();
+}


### PR DESCRIPTION
## What

Restores the system tray and ports it to Tauri v2.

A tray was previously added in #166 (closing the request in #65) and reverted in #312. Per the #312 description, the revert was caused by a Flatpak build failing because of the *single instance* feature that shipped alongside it — *"removing system tray until issues with this are fixed"* — i.e. the tray itself was not the problem. This PR brings the tray back on its own (without single instance) and rebuilds it for Tauri v2.

## Behaviour

- Tray icon with a context menu: **Show/Hide Cinny** and **Quit**.
- **Close to tray** — closing the window hides it instead of quitting; reopen from the icon or menu.
- **Left-click** the icon toggles the window.

## Platform handling

- **Windows / macOS** use Tauri's built-in tray (the `tray-icon` feature).
- **Linux** — Tauri's `tray-icon` backend uses libayatana-appindicator, whose GTK implementation never forwards a left-click / SNI `Activate` event to the app; only the context menu works. To provide proper left-click-to-toggle, the StatusNotifierItem is implemented directly with [`ksni`](https://crates.io/crates/ksni) — the same native-SNI approach Qt apps (e.g. Nextcloud) use. The `tray-icon` feature is scoped to non-Linux desktop targets, which also keeps `libappindicator` out of the Linux build.

## Notes

- The pre-existing `// mod menu;` (macOS application menu) is left commented out as before; this PR does not touch it.
- Tested on Linux / KDE Plasma: tray icon, left-click toggle, context menu and close-to-tray all work.
