### PR TITLE
chore: bump cinny version in cargo.lock

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -521,7 +521,7 @@ checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "cinny"
-version = "4.12.2"
+version = "4.12.4"
 dependencies = [
  "serde",
  "serde_json",


### PR DESCRIPTION
Re https://github.com/cinnyapp/cinny-desktop/pull/588.

I’m packaging cinny-desktop for Arch Linux. To keep the package reproducible, I build the app with `npm run tauri build --bundles deb -- --locked`, but that fails if the cinny version in Cargo.lock doesn’t match the one in Cargo.toml.

So please update the Cargo.toml on release, at least the cinny version in it.

Also, it’s a bit annoying that I can’t open an issue or discussion on cinny-desktop at all, and I also can’t comment on my own PR. But whatever :)
Opening a trivial PR seemed more fitting than a discussion in the cinny repo.
