### PR TITLE
chore: build binary for windows without updater

### DIFF
--- a/.github/workflows/tauri2.yml
+++ b/.github/workflows/tauri2.yml
@@ -1,0 +1,51 @@
+name: "Publish Tauri App (no updater)"
+on:
+  release:
+    types: [published]
+
+jobs:
+  # Windows-x86_64
+  windows-x86_64:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with: 
+          submodules: true
+      - name: Setup node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: ".node-version"
+          package-manager-cache: false
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable # They use branch based releases
+      - name: Install cinny dependencies
+        run: cd cinny && npm ci
+      - name: Install tauri dependencies
+        run: npm ci
+      - name: Disble updater
+        run: git apply 0001-disable-tauri-updater.patch
+      - name: Build desktop app with Tauri
+        uses: tauri-apps/tauri-action@73fb865345c54760d875b94642314f8c0c894afa # v0.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          NODE_OPTIONS: "--max_old_space_size=4096"
+      - name: Get app version (windows)
+        run: |
+          $json = (Get-Content "src-tauri\tauri.conf.json" -Raw) | ConvertFrom-Json
+          $version = $json.version
+          echo "Version: ${version}"
+          echo "TAURI_VERSION=${version}" >> $Env:GITHUB_ENV
+          echo "${Env:TAURI_VERSION}"
+        shell: pwsh
+      - name: Move msi
+        run: Move-Item "src-tauri\target\release\bundle\msi\Cinny_${{ env.TAURI_VERSION }}_x64_en-US.msi" "src-tauri\target\release\bundle\msi\Cinny_desktop-x86_64-no_updater.msi"
+        shell: pwsh
+      - name: Upload tagged release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: |
+            src-tauri/target/release/bundle/msi/Cinny_desktop-x86_64-no_updater.msi

--- a/0001-disable-tauri-updater.patch
+++ b/0001-disable-tauri-updater.patch
@@ -1,0 +1,10 @@
+diff --git a/src-tauri/Cargo.toml b/src-tauri/Cargo.toml
+index c998577..c92139e 100644
+--- a/src-tauri/Cargo.toml
++++ b/src-tauri/Cargo.toml
+@@ -35,3 +35,3 @@ tauri-plugin-dialog = "2.7.1"
+ # when `tauri dev` runs it is executed with `cargo run --no-default-features` if `devPath` is an URL
+-default = [ "custom-protocol", "updater" ]
++default = [ "custom-protocol" ]
+ # this feature is used used for production builds where `devPath` points to the filesystem
+ 


### PR DESCRIPTION
Build and provide a binary for windows without updater active. This could be good use for tools like scoop which install app without any privilege but updater override that once someone update the app through inbuilt updater.